### PR TITLE
refactor(entity): изменение ограничений сущности User

### DIFF
--- a/src/main/java/com/example/auth/entity/User.java
+++ b/src/main/java/com/example/auth/entity/User.java
@@ -7,6 +7,8 @@ import lombok.*;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import org.hibernate.annotations.Generated;
+import org.hibernate.generator.EventType;
 
 @Entity
 @Getter
@@ -26,7 +28,7 @@ public class User {
     @Column(name = "number_phone",unique = true,length = 11,nullable = false)
     private String numberPhone;
 
-    @Column(name = "email",unique = true,length = 20,nullable = false)
+    @Column(name = "email",unique = true,nullable = false)
     private String email;
 
     @Column(name = "password",nullable = false,length = 100)
@@ -35,7 +37,8 @@ public class User {
     @Column(name = "firstname",length = 30,nullable = false)
     private String firstname;
 
-    @Column(name = "created_at",nullable = false,updatable = false)
+    @Column(name = "created_at",nullable = false,updatable = false,insertable = false)
+    @Generated(event = EventType.INSERT)
     private LocalDateTime createdAt;
 
 

--- a/src/main/resources/db/migration/V3__create_table_users.sql
+++ b/src/main/resources/db/migration/V3__create_table_users.sql
@@ -1,7 +1,7 @@
 CREATE TABLE users(
 id uuid primary key default gen_random_uuid(),
 number_phone varchar (11) not null unique,
-email varchar(20) not  null  unique ,
+email varchar(255) not  null  unique ,
 password varchar(100) not  null ,
 firstname varchar(30) not null ,
 created_at timestamp with time zone not null default now()


### PR DESCRIPTION
- Удалено ограничение длины для email (теперь по умолчанию 255)
- Добавлен @Generated для автоматического управления createdAt в БД
- Установлен insertable=false для createdAt
- Обновлена миграция для email varchar(255)