### PR TITLE
Обновление зависимостей в pom.xml для поддержки Swagger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,20 @@
 			<version>3.5.0</version>
 		</dependency>
 
+		<!-- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.8</version>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations -->
+		<dependency>
+			<groupId>io.swagger.core.v3</groupId>
+			<artifactId>swagger-annotations</artifactId>
+			<version>2.2.31</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/example/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/auth/config/SecurityConfig.java
@@ -21,13 +21,18 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
-       httpSecurity
-               .authorizeHttpRequests(auth->auth
-                       .requestMatchers("/api/v1/auth/**").permitAll()
-                       .anyRequest().authenticated())
-               .csrf(AbstractHttpConfigurer::disable)
-               .httpBasic(Customizer.withDefaults());
-       return httpSecurity.build();
+        httpSecurity
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/v1/auth/**",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(Customizer.withDefaults());
+        return httpSecurity.build();
     }
 
 

--- a/src/main/java/com/example/auth/controller/AuthControllerImpl.java
+++ b/src/main/java/com/example/auth/controller/AuthControllerImpl.java
@@ -5,6 +5,10 @@ import com.example.auth.dto.*;
 import com.example.auth.service.jwt.AuthTokenService;
 import com.example.auth.service.jwt.CookieService;
 import com.example.auth.service.register.UserRegistrationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,13 +18,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 
-
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/auth")
 public class AuthControllerImpl implements AuthController {
 
     private static final String AUTH_HEADER_PREFIX = "Bearer ";
+    private static final String USER_TAG = "User";
 
     private final UserRegistrationService userRegistrationService;
     private final CookieService cookieService;
@@ -28,6 +32,18 @@ public class AuthControllerImpl implements AuthController {
 
     @Override
     @PostMapping("/register")
+    @Operation(
+            summary = "Метод для регистрации пользователей ",
+            description = "Создает нового пользователя с уникальным номером телефона и email",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "При успешной регистрации пользователя"),
+                    @ApiResponse(responseCode = "400", description = "Неверные данные"),
+                    @ApiResponse(responseCode = "409", description = "Конфликт введённых данных с уже существующими в базе данных")
+            },
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Данные для регистрации нового пользователя", required = true
+            ),
+            tags = {USER_TAG, "Registration"})
     public ResponseEntity<UserRegisterResponse> registerUser(
             @Valid @RequestBody UserRegisterRequest registerRequest,
             HttpServletResponse response) {
@@ -45,6 +61,28 @@ public class AuthControllerImpl implements AuthController {
 
     @Override
     @PostMapping("/refresh")
+    @Operation(
+            summary = "Обновляет пару токенов",
+            description = "Генерирует новую пару access/refresh токенов на основе валидного refresh-" +
+                    "токена из cookie",
+            responses = {
+                    @ApiResponse(responseCode = "201",
+                            description = "Токены успешно обновлены. Новый access-токен возвращается в " +
+                                    "заголовке Authorization, " +
+                                    "refresh-токен — в cookie."),
+                    @ApiResponse(responseCode = "401", description =
+                            "Невалидный refresh-токен (отозван, просрочен или некорректен)"),
+
+            },
+            parameters = {
+                    @Parameter(
+                            name = "refreshToken",
+                            description = "Refresh token из cookie для обновления токенов",
+                            in = ParameterIn.COOKIE,
+                            required = true
+                    )
+            }
+    )
     public ResponseEntity<Void> refreshTokens(
             @CookieValue("${spring.security.jwt.cookie.name}") String refreshToken,
             HttpServletResponse response) {
@@ -57,13 +95,30 @@ public class AuthControllerImpl implements AuthController {
                 .build();
     }
 
+    @Override
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest,HttpServletResponse servletResponse) {
+    @Operation(
+            summary = "Авторизация пользователя",
+            description = "Метод для аутентификации пользователя. Принимает данные для входа (email и пароль), проверяет их " +
+                    "на валидность и, если аутентификация успешна, генерирует пару токенов (access и refresh), возвращая их " +
+                    "в ответ. Refresh токен сохраняется в cookie, а access токен передается в заголовке Authorization.",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "При успешной авторизации, возвращены токены (access и refresh)."),
+                    @ApiResponse(responseCode = "400", description = "Неверные данные (неправильный формат email или пароля)."),
+                    @ApiResponse(responseCode = "401", description = "Неверные учетные данные (неверный пароль)."),
+                    @ApiResponse(responseCode = "404", description = "Пользователь не найден по номеру телефона."),
+                    @ApiResponse(responseCode = "423", description = "Аккаунт заблокирован. Попробуйте через некоторое время.")
+            },
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Данные для авторизации пользователя", required = true),
+            tags = {USER_TAG, "Registration"}
+    )
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest, HttpServletResponse servletResponse) {
         LoginResponse loginResponse = userRegistrationService.login(loginRequest);
         cookieService.setRefreshTokenCookie(servletResponse, loginResponse.getRefreshToken());
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .header(HttpHeaders.AUTHORIZATION,AUTH_HEADER_PREFIX + loginResponse.getAccessToken())
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER_PREFIX + loginResponse.getAccessToken())
                 .body(loginResponse);
     }
 

--- a/src/main/java/com/example/auth/service/register/UserRegistrationServiceImpl.java
+++ b/src/main/java/com/example/auth/service/register/UserRegistrationServiceImpl.java
@@ -45,7 +45,6 @@ public class UserRegistrationServiceImpl implements UserRegistrationService {
     @Override
     public LoginResponse login(LoginRequest loginRequest) {
         String normalizedPhone = PhoneNormalizer.normalize(loginRequest.getNumberPhone());
-
         loginAttemptService.checkIfBlocked(normalizedPhone);
         User user = userService.findByNumberPhone(normalizedPhone);
         validatePasswordAndHandleAttempts(loginRequest.getRawPassword(), user,normalizedPhone);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,6 +66,14 @@ spring:
 
 
 
-
+springdoc:
+  swagger-ui:
+    path: /swagger-ui/index.html  # стандартный путь
+    tags-sorter: alpha      # сортировка тегов по алфавиту
+    operations-sorter: alpha # сортировка операций по алфавиту
+    persistAuthorization: true  # Сохранять авторизацию между перезагрузками
+    withCredentials: true       # Разрешить передачу cookies
+  api-docs:
+    path: /v3/api-docs      # путь к JSON-спецификации OpenAPI
 
 


### PR DESCRIPTION
docs: разрешить публичный доступ к Swagger UI

- Добавлены пути `/swagger-ui/**` и `/v3/api-docs/**` в permitAll()
- Теперь документация API доступна без аутентификации

docs: добавлена Swagger-документация для AuthController

- Добавлены аннотации @Operation, @ApiResponse для всех endpoint'ов
- Подробно описаны:
  * /register - процесс регистрации
  * /refresh - обновление токенов
  * /login - авторизация пользователя
- Указаны все возможные коды ответов и ошибок
- Добавлены описания request/response моделей
- Введены теги для группировки операций

chore: обновление конфигурации приложения

- Добавлены настройки SpringDoc/Swagger:
  * Пути для UI и API docs